### PR TITLE
Add support for optparse-generic 1.5

### DIFF
--- a/app/GenKeyPair.hs
+++ b/app/GenKeyPair.hs
@@ -15,10 +15,8 @@ import           Control.Monad.Trans       (lift)
 import           Crypto.Random
 import           Data.Maybe
 import qualified Data.Text.IO              as Text.IO
-import           Filesystem.Path           (FilePath)
-import           Filesystem.Path.CurrentOS (encodeString)
 import           Options.Generic
-import           Prelude                   hiding (FilePath)
+import           Prelude
 import           System.Exit
 
 import           Gen.Ed25519.KeyPair       (KeyPair (..))
@@ -39,8 +37,8 @@ main :: IO ()
 main = do
   Options{..} <- unwrapRecord "Generate a base64 encoded, Ed25519 keypair"
 
-  let seckeyPath = fromMaybe "./secret-ed25519.key" (encodeString <$> secretKey)
-      pubkeyPath = fromMaybe "./public-ed25519.key" (encodeString <$> publicKey)
+  let seckeyPath = fromMaybe "./secret-ed25519.key" secretKey
+      pubkeyPath = fromMaybe "./public-ed25519.key" publicKey
 
   -- NB: 32 is a magic constant that's not exposed by the Ed25519
   -- module and is the required key length to create a SecretKey

--- a/app/SignKeyPair.hs
+++ b/app/SignKeyPair.hs
@@ -16,10 +16,8 @@ import           Control.Monad.Trans       (lift)
 import qualified Crypto.PubKey.Ed25519     as Ed25519
 import           Data.ByteString           (ByteString)
 import qualified Data.Text.IO              as Text.IO
-import           Filesystem.Path           (FilePath)
-import           Filesystem.Path.CurrentOS (encodeString)
 import           Options.Generic
-import           Prelude                   hiding (FilePath)
+import           Prelude
 import           System.Exit
 
 import qualified Gen.Ed25519.KeyPair       as KeyPair
@@ -43,8 +41,8 @@ main = do
         KeyPair.parseKey constructor =<< Text.IO.readFile path
 
   result <- Except.runExceptT $ do
-    seckey <- lift $ readKey Ed25519.secretKey (encodeString secretKey)
-    pubkey <- lift $ readKey Ed25519.publicKey (encodeString publicKey)
+    seckey <- lift $ readKey Ed25519.secretKey secretKey
+    pubkey <- lift $ readKey Ed25519.publicKey publicKey
 
     sig <- KeyPair.encode64 (KeyPair.sign KeyPair.KeyPair{..} msg)
     lift $ Text.IO.putStrLn sig

--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,7 @@
 let
-  rev = "9899f2b5602a6a8be6e79725d39856025861a5d0";
+  rev = "75a35fd777948666c6175c73e08d0f0bc1a7974e";
 
-  sha256 = "0zb05xxhy1zynpf9014a3jrv6hibs0zz855vc8x4x5hcjpx34dlc";
+  sha256 = "04cbj56i5qnaa93fam5k4lpz6im5bh5zl1811z78wga3iz3xcfca";
 
   pkgs =
     import

--- a/gen-ed25-keypair.cabal
+++ b/gen-ed25-keypair.cabal
@@ -23,7 +23,7 @@ library
               , memory                >= 0.13
               , mtl                   >= 2.2
               , optparse-applicative
-              , optparse-generic      >= 1.4.0 && < 1.5
+              , optparse-generic      >= 1.4.0 && < 1.6
               , text                  >= 1.2
 
   default-language:    Haskell2010
@@ -37,7 +37,6 @@ executable gen-ed25-keypair
               , gen-ed25-keypair
               , cryptonite
               , mtl
-              , system-filepath
               , optparse-generic
               , text
 
@@ -53,7 +52,6 @@ executable sign-ed25
               , cryptonite
               , mtl
               , optparse-generic
-              , system-filepath
               , text
               , gen-ed25-keypair
 


### PR DESCRIPTION
Things done:
- Switch `system-filepath` to `filepath`
- Bump version bound on `optparse-generic`
- Bump nixpkgs pin